### PR TITLE
Add live demo simulation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,33 @@ python -m src.dashboard
 
 The monitor and dashboard communicate through the shared SQLite database.
 
+### Demo Mode
+
+The system includes a built-in demo that simulates a ransomware attack through the full detection pipeline. No real malware is involved -- the demo creates temporary files in `/tmp/ransomware_demo/` and feeds synthetic events through the analysis engine.
+
+**From the dashboard:** Click the **Run Demo** button in the navbar. The demo runs four phases (normal activity, suspicious activity, ransomware attack, recovery) and you can watch events appear in the live feed, threat scores rise, and the response engine fire.
+
+**From the command line:**
+
+```bash
+# Start a demo (polls until complete)
+python -m src.demo.simulate
+
+# Run at 2x speed
+python -m src.demo.simulate --speed 2.0
+
+# Stop a running demo
+python -m src.demo.simulate --stop
+```
+
+**Demo API endpoints:**
+
+| Method | Endpoint            | Description                     |
+|--------|---------------------|---------------------------------|
+| POST   | `/api/demo/start`   | Start demo (optional `{"speed": 1.0}`) |
+| POST   | `/api/demo/stop`    | Stop a running demo             |
+| GET    | `/api/demo/status`  | Current demo status and progress |
+
 ### CLI Flags
 
 | Flag              | Applies To       | Default       | Description                    |
@@ -314,6 +341,9 @@ All endpoints are prefixed with `/api`.
 | POST   | `/api/restore`    | Restore files (`{"backup_id": 1}`, `{"backup_ids": [1,2]}`, or `{"process_name": "..."}`) |
 | GET    | `/api/config`     | Current configuration                |
 | PUT    | `/api/config`     | Update configuration (merge)         |
+| POST   | `/api/demo/start` | Start demo simulation (optional `{"speed": 1.0}`) |
+| POST   | `/api/demo/stop`  | Stop a running demo                  |
+| GET    | `/api/demo/status` | Demo status (`running`, `phase`, `progress`) |
 | WS     | `/ws/live`        | WebSocket for real-time event streaming |
 
 ### WebSocket Messages

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -358,6 +358,56 @@ Charts update when you switch to the tab. They provide a useful overview for und
 
 ---
 
+## 6a. Demo Mode
+
+The system includes a live demo that simulates a full ransomware attack through the detection pipeline. No real malware is used -- the demo creates temporary files and feeds synthetic events through the analysis engine so you can see the system in action.
+
+### Running the Demo from the Dashboard
+
+1. Start the dashboard: `python run.py --dashboard-only`
+2. Open your browser to **http://localhost:5000**
+3. Click the **Run Demo** button in the top navbar
+4. Watch the four phases unfold:
+   - **Normal Activity** -- Routine file operations with low entropy changes
+   - **Suspicious Activity** -- Faster modifications, some extension changes, rising threat score
+   - **Ransomware Attack** -- Mass encryption across multiple directories, high entropy spikes, threat alert fires
+   - **Recovery** -- Threat contained and files restored
+5. Events appear in the live feed, threat scores rise in the Monitor tab, and threats appear in the Threats tab
+6. Click the button again (now labelled **Stop Demo**) to end the simulation early
+
+### Running the Demo from the Command Line
+
+A standalone CLI script can trigger the demo without opening a browser:
+
+```bash
+# Start a demo and poll until complete
+python -m src.demo.simulate
+
+# Run at double speed
+python -m src.demo.simulate --speed 2.0
+
+# Connect to a dashboard on a different host/port
+python -m src.demo.simulate --base-url http://192.168.1.42:8080
+
+# Stop a running demo
+python -m src.demo.simulate --stop
+```
+
+### What the Demo Creates
+
+The demo creates a temporary directory at `/tmp/ransomware_demo/` with text files that are then "encrypted" (overwritten with random bytes) to simulate a real attack. The directory is cleaned up automatically when the demo finishes or is stopped.
+
+### Demo Phases in Detail
+
+| Phase              | Events | Entropy Delta | What Happens                            |
+|--------------------|--------|---------------|-----------------------------------------|
+| Normal Activity    | 6      | 0.1 - 0.5    | Files created and modified normally     |
+| Suspicious Activity| 10     | 0.3 - 2.5    | Faster modifications, some .txt to .enc |
+| Ransomware Attack  | 25+    | 3.5 - 4.2    | Mass encryption, .locked extensions     |
+| Recovery           | 4      | --            | Process suspended, files restored       |
+
+---
+
 ## 7. Understanding Threat Alerts
 
 When the system detects suspicious behaviour, it assigns a threat score based on six indicators. Understanding these helps you decide whether an alert is real or a false positive.

--- a/src/dashboard/api/routes.py
+++ b/src/dashboard/api/routes.py
@@ -14,6 +14,11 @@ Implements the exact endpoints from the Phase 6 docs:
 
 import json
 import logging
+import os
+import random
+import shutil
+import threading
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -347,3 +352,306 @@ def _deep_merge(base: dict, override: dict):
             _deep_merge(base[key], value)
         else:
             base[key] = value
+
+
+# ------------------------------------------------------------------
+# Demo simulation
+# ------------------------------------------------------------------
+
+_demo_thread = None
+_demo_stop_event = threading.Event()
+_demo_status = {"running": False, "phase": "idle", "progress": 0}
+
+DEMO_DIR = "/tmp/ransomware_demo"
+DEMO_PID = 99999
+DEMO_PROCESS = "demo_app.exe"
+
+
+def _broadcast_demo_status(phase, progress, description):
+    _demo_status["phase"] = phase
+    _demo_status["progress"] = progress
+    if _ws_handler:
+        _ws_handler.broadcast("demo_status", {
+            "phase": phase,
+            "progress": progress,
+            "description": description,
+        })
+
+
+def _make_demo_event(event_type, file_path, entropy_delta=0.0, old_path=None):
+    ev = {
+        "event_type": event_type,
+        "file_path": file_path,
+        "process_id": DEMO_PID,
+        "process_name": DEMO_PROCESS,
+        "timestamp": datetime.now().isoformat(),
+        "entropy_delta": entropy_delta,
+    }
+    if old_path:
+        ev["old_path"] = old_path
+    return ev
+
+
+def _write_demo_file(path, content=None):
+    """Write a real file so entropy analysis can work on it."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if content is None:
+        content = "The quick brown fox jumps over the lazy dog.\n" * 20
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def _write_encrypted_file(path):
+    """Write pseudo-encrypted content (high entropy random bytes)."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(os.urandom(1024))
+
+
+def _emit_event(ev):
+    """Broadcast event via WebSocket and log to database."""
+    if _ws_handler:
+        _ws_handler.broadcast("file_event", ev)
+    if _event_logger:
+        try:
+            _event_logger.log_event(
+                event_type=ev["event_type"],
+                file_path=ev["file_path"],
+                process_id=ev.get("process_id"),
+                process_name=ev.get("process_name"),
+            )
+        except Exception:
+            logger.debug("Demo: could not log event to database")
+
+
+def _feed_analyzer(ev):
+    """Feed event through the behavior analyzer pipeline."""
+    if not _behavior_analyzer:
+        return
+    try:
+        _behavior_analyzer.process_event(ev)
+    except Exception:
+        logger.debug("Demo: behavior analyzer could not process event")
+
+
+def _run_demo_simulation(stop_event, speed):
+    """Run the 4-phase demo in a background thread."""
+    global _demo_status
+
+    delay = lambda s: time.sleep(s / speed)
+
+    # Setup: create demo directory
+    if os.path.exists(DEMO_DIR):
+        shutil.rmtree(DEMO_DIR)
+    os.makedirs(DEMO_DIR, exist_ok=True)
+
+    try:
+        # -------------------------------------------------------
+        # Phase 1: Normal Activity (~8s)
+        # -------------------------------------------------------
+        _broadcast_demo_status("normal_activity", 0,
+                               "Simulating normal file operations")
+        normal_files = [
+            os.path.join(DEMO_DIR, f"document_{i}.txt") for i in range(6)
+        ]
+        for i, fpath in enumerate(normal_files):
+            if stop_event.is_set():
+                return
+            _write_demo_file(fpath)
+            etype = "created" if i < 3 else "modified"
+            ev = _make_demo_event(etype, fpath,
+                                  entropy_delta=round(random.uniform(0.1, 0.5), 2))
+            _emit_event(ev)
+            pct = int((i + 1) / 6 * 20)
+            _broadcast_demo_status("normal_activity", pct,
+                                   f"Normal file operation: {os.path.basename(fpath)}")
+            delay(1.3)
+
+        # -------------------------------------------------------
+        # Phase 2: Suspicious Activity (~10s)
+        # -------------------------------------------------------
+        _broadcast_demo_status("suspicious_activity", 20,
+                               "Increasing file modification rate")
+        for i in range(10):
+            if stop_event.is_set():
+                return
+            idx = i % len(normal_files)
+            fpath = normal_files[idx]
+            _write_demo_file(fpath, "Modified content v" + str(i) + "\n" * 50)
+
+            entropy_d = round(random.uniform(0.3, 1.0), 2)
+            etype = "modified"
+            old_path = None
+
+            # A couple of extension changes
+            if i in (4, 7):
+                new_path = fpath.replace(".txt", ".enc")
+                os.rename(fpath, new_path)
+                old_path = fpath
+                fpath = new_path
+                normal_files[idx] = new_path
+                etype = "modified"
+                entropy_d = round(random.uniform(1.5, 2.5), 2)
+
+            ev = _make_demo_event(etype, fpath, entropy_delta=entropy_d,
+                                  old_path=old_path)
+            _emit_event(ev)
+            _feed_analyzer(ev)
+
+            pct = 20 + int((i + 1) / 10 * 25)
+            _broadcast_demo_status("suspicious_activity", pct,
+                                   f"Suspicious: rapid modifications detected")
+            delay(1.0)
+
+        # -------------------------------------------------------
+        # Phase 3: Ransomware Attack (~12s)
+        # -------------------------------------------------------
+        _broadcast_demo_status("ransomware_attack", 45,
+                               "Ransomware-like encryption pattern detected")
+
+        attack_dirs = [
+            os.path.join(DEMO_DIR, d)
+            for d in ["docs", "photos", "projects", "backups", "reports"]
+        ]
+        for d in attack_dirs:
+            os.makedirs(d, exist_ok=True)
+
+        attack_files = []
+        for d in attack_dirs:
+            for j in range(5):
+                attack_files.append(os.path.join(d, f"file_{j}.txt"))
+
+        for i, fpath in enumerate(attack_files):
+            if stop_event.is_set():
+                return
+            # Write original then overwrite with "encrypted" content
+            _write_demo_file(fpath)
+            _write_encrypted_file(fpath)
+
+            entropy_d = round(random.uniform(3.5, 4.2), 2)
+
+            # Rename to .locked extension
+            locked_path = fpath.replace(".txt", ".locked")
+            try:
+                os.rename(fpath, locked_path)
+            except OSError:
+                locked_path = fpath
+
+            ev = _make_demo_event("modified", locked_path,
+                                  entropy_delta=entropy_d,
+                                  old_path=fpath)
+            _emit_event(ev)
+            _feed_analyzer(ev)
+
+            # Also emit some deletion events
+            if i % 5 == 0:
+                del_ev = _make_demo_event("deleted", fpath, entropy_delta=0.0)
+                _emit_event(del_ev)
+                _feed_analyzer(del_ev)
+
+            pct = 45 + int((i + 1) / len(attack_files) * 40)
+            _broadcast_demo_status("ransomware_attack", pct,
+                                   f"Encrypting files in {os.path.basename(os.path.dirname(locked_path))}/")
+            delay(0.4)
+
+        # -------------------------------------------------------
+        # Phase 4: Recovery (~6s)
+        # -------------------------------------------------------
+        _broadcast_demo_status("recovery", 85,
+                               "Threat contained - beginning recovery")
+
+        recovery_msgs = [
+            "Process demo_app.exe suspended",
+            "Emergency backups verified",
+            "Restoring encrypted files",
+            "Recovery complete",
+        ]
+        for i, msg in enumerate(recovery_msgs):
+            if stop_event.is_set():
+                return
+            pct = 85 + int((i + 1) / len(recovery_msgs) * 15)
+            _broadcast_demo_status("recovery", pct, msg)
+            delay(1.5)
+
+        _broadcast_demo_status("complete", 100,
+                               "Demo simulation finished")
+
+    finally:
+        # Cleanup temp files
+        try:
+            if os.path.exists(DEMO_DIR):
+                shutil.rmtree(DEMO_DIR)
+        except OSError:
+            pass
+
+        _demo_status["running"] = False
+        _demo_status["phase"] = "complete"
+        _demo_status["progress"] = 100
+
+
+# ------------------------------------------------------------------
+# POST /api/demo/start
+# ------------------------------------------------------------------
+
+@api.route("/demo/start", methods=["POST"])
+def demo_start():
+    """Start the demo simulation in a background thread."""
+    global _demo_thread, _demo_stop_event
+
+    if _demo_status.get("running"):
+        return jsonify({"error": "Demo is already running"}), 409
+
+    data = request.get_json(silent=True) or {}
+    speed = max(0.1, float(data.get("speed", 1.0)))
+
+    _demo_stop_event = threading.Event()
+    _demo_status["running"] = True
+    _demo_status["phase"] = "starting"
+    _demo_status["progress"] = 0
+
+    _demo_thread = threading.Thread(
+        target=_run_demo_simulation,
+        args=(_demo_stop_event, speed),
+        daemon=True,
+    )
+    _demo_thread.start()
+
+    return jsonify({"started": True, "speed": speed})
+
+
+# ------------------------------------------------------------------
+# POST /api/demo/stop
+# ------------------------------------------------------------------
+
+@api.route("/demo/stop", methods=["POST"])
+def demo_stop():
+    """Stop a running demo simulation."""
+    if not _demo_status.get("running"):
+        return jsonify({"error": "No demo is running"}), 409
+
+    _demo_stop_event.set()
+    _demo_status["running"] = False
+    _demo_status["phase"] = "stopped"
+
+    if _ws_handler:
+        _ws_handler.broadcast("demo_status", {
+            "phase": "stopped",
+            "progress": _demo_status["progress"],
+            "description": "Demo stopped by user",
+        })
+
+    return jsonify({"stopped": True})
+
+
+# ------------------------------------------------------------------
+# GET /api/demo/status
+# ------------------------------------------------------------------
+
+@api.route("/demo/status", methods=["GET"])
+def demo_status():
+    """Return current demo simulation status."""
+    return jsonify({
+        "running": _demo_status.get("running", False),
+        "phase": _demo_status.get("phase", "idle"),
+        "progress": _demo_status.get("progress", 0),
+    })

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -16,6 +16,10 @@
 <nav class="navbar navbar-dark bg-dark px-3">
     <span class="navbar-brand mb-0 h1">Ransomware Detection System</span>
     <div class="d-flex align-items-center gap-3 text-white">
+        <button class="btn btn-sm btn-outline-warning" id="demo-btn"
+                onclick="toggleDemo()">
+            <i class="bi bi-play-circle"></i> Run Demo
+        </button>
         <span id="header-status">
             <i class="bi bi-circle-fill text-success" id="status-dot"></i>
             <span id="status-text">Protected</span>

--- a/src/demo/simulate.py
+++ b/src/demo/simulate.py
@@ -1,0 +1,97 @@
+"""Standalone CLI script to trigger a demo simulation via the dashboard API.
+
+Usage:
+    python -m src.demo.simulate                    # start demo, poll until complete
+    python -m src.demo.simulate --speed 2.0        # run at 2x speed
+    python -m src.demo.simulate --stop             # stop a running demo
+    python -m src.demo.simulate --base-url http://host:port
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def _post(url, data=None):
+    body = json.dumps(data or {}).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read()), resp.status
+    except urllib.error.HTTPError as exc:
+        return json.loads(exc.read()), exc.code
+
+
+def _get(url):
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read()), resp.status
+    except urllib.error.HTTPError as exc:
+        return json.loads(exc.read()), exc.code
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Trigger a demo simulation")
+    parser.add_argument(
+        "--base-url", default="http://127.0.0.1:5000",
+        help="Base URL of the dashboard (default: http://127.0.0.1:5000)",
+    )
+    parser.add_argument(
+        "--speed", type=float, default=1.0,
+        help="Speed multiplier for the simulation (default: 1.0)",
+    )
+    parser.add_argument(
+        "--stop", action="store_true",
+        help="Stop a running demo instead of starting one",
+    )
+    args = parser.parse_args()
+
+    base = args.base_url.rstrip("/")
+
+    if args.stop:
+        data, status = _post(base + "/api/demo/stop")
+        if status == 200:
+            print("Demo stopped.")
+        else:
+            print("Error:", data.get("error", "unknown"))
+        return
+
+    # Start the demo
+    data, status = _post(base + "/api/demo/start", {"speed": args.speed})
+    if status != 200:
+        print("Failed to start demo:", data.get("error", "unknown"))
+        sys.exit(1)
+
+    print(f"Demo started (speed={args.speed}x). Polling status...")
+
+    # Poll until complete
+    while True:
+        time.sleep(2)
+        try:
+            data, _ = _get(base + "/api/demo/status")
+        except Exception as exc:
+            print(f"  Error polling status: {exc}")
+            continue
+
+        phase = data.get("phase", "?")
+        progress = data.get("progress", 0)
+        running = data.get("running", False)
+        print(f"  [{phase}] {progress}%")
+
+        if not running or phase in ("complete", "stopped"):
+            break
+
+    print("Demo finished.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduce a demo mode that simulates a ransomware attack through the full detection pipeline without real malware. The simulation runs four phases (normal activity, suspicious activity, ransomware attack, and recovery) using temporary files in /tmp/ransomware_demo/.

- Add POST /api/demo/start, POST /api/demo/stop, GET /api/demo/status endpoints with background thread execution
- Add Run Demo button to dashboard navbar with WebSocket progress updates
- Add standalone CLI script (python -m src.demo.simulate) for headless use
- Document demo mode in README.md and USER_GUIDE.md